### PR TITLE
Add support of the new insights

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -214,7 +214,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps, Spa
               </span>
               <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
               <span className="icons-container">
-                {this.state.insights.length > 0 && (
+                {mostImportantInsight && mostImportantInsight.importance < 3 && (
                   <Tooltip title="Insights available">
                     <span className="icon">
                       <LightBulbIcon size={12} color={insightIconColor} />

--- a/packages/jaeger-ui/src/components/common/InsightIcon/types.ts
+++ b/packages/jaeger-ui/src/components/common/InsightIcon/types.ts
@@ -22,9 +22,11 @@ export enum InsightType {
   SpanNPlusOne = 'SpaNPlusOne',
   SpanEndpointBottleneck = 'SpanEndpointBottleneck',
   SpanDurations = 'SpanDurations',
-  SpanScaling = 'SpanScaling',
-  SpanScalingRootCause = 'SpanScalingRootCause',
+  SpanScalingBadly = 'SpanScaling',
   SpanDurationBreakdown = 'SpanDurationBreakdown',
   EndpointDurationSlowdown = 'EndpointDurationSlowdown',
   EndpointBreakdown = 'EndpointBreakdown',
+  EndpointSessionInView = 'EndpointSessionInView',
+  EndpointChattyApi = 'EndpointChattyApi',
+  EndpointHighNumberOfQueries = 'EndpointHighNumberOfQueries',
 }

--- a/packages/jaeger-ui/src/components/common/InsightIcon/utils.ts
+++ b/packages/jaeger-ui/src/components/common/InsightIcon/utils.ts
@@ -56,7 +56,7 @@ export const getInsightTypeInfo = (
     },
     [InsightType.SlowestSpans]: {
       icon: BottleneckIcon,
-      label: 'Span Bottleneck',
+      label: 'Bottleneck',
     },
     [InsightType.EndpointSpanNPlusOne]: {
       icon: SQLDatabaseIcon,
@@ -70,13 +70,9 @@ export const getInsightTypeInfo = (
       icon: BottleneckIcon,
       label: 'Bottleneck',
     },
-    [InsightType.SpanScaling]: {
+    [InsightType.SpanScalingBadly]: {
       icon: ScalesIcon,
       label: 'Scaling Issue Found',
-    },
-    [InsightType.SpanScalingRootCause]: {
-      icon: ScalesIcon,
-      label: 'Scaling Issue Root Cause Found',
     },
     [InsightType.SpanUsages]: {
       icon: SineIcon,
@@ -97,6 +93,18 @@ export const getInsightTypeInfo = (
     [InsightType.EndpointBreakdown]: {
       icon: PieChartIcon,
       label: 'Request Breakdown',
+    },
+    [InsightType.EndpointSessionInView]: {
+      icon: SQLDatabaseIcon,
+      label: 'Session in View Query Detected',
+    },
+    [InsightType.EndpointChattyApi]: {
+      icon: SQLDatabaseIcon,
+      label: 'Excessive API Calls Detected',
+    },
+    [InsightType.EndpointHighNumberOfQueries]: {
+      icon: SQLDatabaseIcon,
+      label: 'High number of queries',
     },
   };
 
@@ -128,13 +136,16 @@ export const getInsightTypeOrderPriority = (type: string): number => {
 
     [InsightType.SpanDurations]: 60,
     [InsightType.SpanUsages]: 61,
-    [InsightType.SpanScaling]: 63,
+    [InsightType.SpanScalingBadly]: 63,
     [InsightType.SpanNPlusOne]: 65,
     [InsightType.SpanDurationChange]: 66,
     [InsightType.SpanEndpointBottleneck]: 67,
     [InsightType.SpanDurationBreakdown]: 68,
 
     [InsightType.EndpointSpanNPlusOne]: 55,
+    [InsightType.EndpointSessionInView]: 56,
+    [InsightType.EndpointChattyApi]: 57,
+    [InsightType.EndpointHighNumberOfQueries]: 58,
     [InsightType.SlowestSpans]: 40,
     [InsightType.LowUsage]: 30,
     [InsightType.NormalUsage]: 50,


### PR DESCRIPTION
Add support of the new insights:
- Session in View
- Excessive API Calls
- High number of queries
Closes #37 

Remove indicator for spans without important insights Closes #38 